### PR TITLE
Update automodLinks.ts

### DIFF
--- a/src/listeners/automod/automodLinks.ts
+++ b/src/listeners/automod/automodLinks.ts
@@ -52,7 +52,7 @@ export const automodLinks: ListenerHandler = async (
     const blockedLinks = blockedLinkList.length;
     const allowedLinks = allowedLinkList.length;
 
-    if (blockedLinks > 0 && blockedLinks !== allowedLinks) {
+    if (blockedLinks > 0 && blockedLinks > allowedLinks) {
       if (message.deletable) {
         await message.delete();
       }


### PR DESCRIPTION
fix: patch bug in level logic

# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description
At line 55, I changed the following code, which now allows links to be not blocked.
```diff
- if (blockedLinks > 0 && blockedLinks !== allowedLinks)
+ if (blockedLinks > 0 && blockedLinks > allowedLinks)
```
## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #1809

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
